### PR TITLE
[refactor]check bsky with accountUnread

### DIFF
--- a/src/social/client/bsky.service.ts
+++ b/src/social/client/bsky.service.ts
@@ -40,10 +40,9 @@ export class BSkyService {
     }
   };
 
-  health = async (): Promise<void> => {
+  health = async (): Promise<{ count: number }> => {
     await this.login();
-    await this.agent.getProfile({
-      actor: this.configService.get('bsky.identifier'),
-    });
+    const response = await this.agent.countUnreadNotifications();
+    return response.data;
   };
 }

--- a/test/health.e2e-spec.ts
+++ b/test/health.e2e-spec.ts
@@ -15,7 +15,7 @@ jest.mock('twitter-api-client', () => ({
 jest.mock('@atproto/api', () => ({
   BskyAgent: jest.fn().mockImplementation(() => ({
     login: jest.fn(),
-    countUnreadNotifications: jest.fn(),
+    countUnreadNotifications: jest.fn().mockImplementation(() => Promise.resolve({ data: { count: 0 } })),
   })),
 }));
 

--- a/test/health.e2e-spec.ts
+++ b/test/health.e2e-spec.ts
@@ -15,7 +15,7 @@ jest.mock('twitter-api-client', () => ({
 jest.mock('@atproto/api', () => ({
   BskyAgent: jest.fn().mockImplementation(() => ({
     login: jest.fn(),
-    getProfile: jest.fn(),
+    countUnreadNotifications: jest.fn(),
   })),
 }));
 


### PR DESCRIPTION
This pull request includes changes to the `BSkyService` class and its corresponding test file `bsky.service.spec.ts`. The main change is the replacement of the `getProfile` method with `countUnreadNotifications` in the `BSkyService` class and the relevant test mocks. This change also includes updates to the `health` method in `BSkyService` to return the count of unread notifications instead of the profile information.

Here are the key changes:

Changes to `BSkyService` class:

* [`src/social/client/bsky.service.ts`](diffhunk://#diff-96f1fbd4d568a30041e340285e20fe6d4c6e865fc4f473a77c74ad891f470be5L43-R46): The `health` method was updated. Instead of returning profile information, it now returns the count of unread notifications. The `getProfile` method was replaced with `countUnreadNotifications`.

Changes to `bsky.service.spec.ts`:

* [`src/social/client/bsky.service.spec.ts`](diffhunk://#diff-486ffcf5eae68f03e6512ba436e6e4b46717dbccdf04290cd9ae91eeea460f4bL8-L19): The `getProfile` mock function was replaced with `mockCountUnreadNotifications`.
* [`src/social/client/bsky.service.spec.ts`](diffhunk://#diff-486ffcf5eae68f03e6512ba436e6e4b46717dbccdf04290cd9ae91eeea460f4bL37): The `mockConfigService` was removed from the `beforeEach` block in the test suite.
* [`src/social/client/bsky.service.spec.ts`](diffhunk://#diff-486ffcf5eae68f03e6512ba436e6e4b46717dbccdf04290cd9ae91eeea460f4bL66-R74): The test case for the `health` method was updated to match the changes in the `BSkyService` class.

Changes to `health.e2e-spec.ts`:

* [`test/health.e2e-spec.ts`](diffhunk://#diff-64a740c5353beec55521284fd3aa8d475205d665c9be1738fa435396fdd5fff0L18-R18): The `getProfile` mock function was replaced with `countUnreadNotifications`.