### PR TITLE
[feat]add error message to log

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -41,7 +41,7 @@ export class HealthController {
         [service]: { status: 'up' },
       };
     } catch (error) {
-      this.logger.error(`${service} error.message`);
+      this.logger.error(`${service} ${error.message}`);
       return {
         [service]: { status: 'down' },
       };


### PR DESCRIPTION
This pull request includes a minor but significant change to the `HealthController` class in the `src/health/health.controller.ts` file. The change improves error logging by including the actual error message instead of a static string.

In detail, the logger call within the `catch` block has been updated to include the actual `error.message` alongside the `service` name. Previously, it was incorrectly logging the string 'error.message' instead of the actual error message. This will improve debugging and error tracking by providing more detailed logs when a service status check fails.