### PR TITLE
[fix]remove bsky check

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -5,7 +5,6 @@ import {
   HealthIndicatorResult,
 } from '@nestjs/terminus';
 import { TwitterService } from '../social/client/twitter.service';
-import { BSkyService } from '../social/client/bsky.service';
 import { ApiOkResponse } from '@nestjs/swagger';
 import { MetaService } from '../social/client/meta.service';
 
@@ -15,7 +14,6 @@ export class HealthController {
 
   constructor(
     private readonly twitterService: TwitterService,
-    private readonly bskyService: BSkyService,
     private readonly metaService: MetaService,
     private readonly healtCheckService: HealthCheckService,
   ) {}
@@ -26,7 +24,6 @@ export class HealthController {
   async health() {
     return this.healtCheckService.check([
       () => this.checkStatus('twitterClient', this.twitterService.health()),
-      () => this.checkStatus('bskyClient', this.bskyService.health()),
       () => this.checkStatus('metaClient', this.metaService.health()),
     ]);
   }

--- a/test/health.e2e-spec.ts
+++ b/test/health.e2e-spec.ts
@@ -80,13 +80,11 @@ describe('HealthController (e2e)', () => {
           status: 'ok',
           info: {
             twitterClient: { status: 'up' },
-            bskyClient: { status: 'up' },
             metaClient: { status: 'up' },
           },
           error: {},
           details: {
             twitterClient: { status: 'up' },
-            bskyClient: { status: 'up' },
             metaClient: { status: 'up' },
           },
         });


### PR DESCRIPTION
This pull request primarily involves the removal of the `BSkyService` from the `HealthController` class in the `src/health/health.controller.ts` file. This service was previously used to check the health status of the 'bskyClient', but it is no longer needed and has been removed from the import statements, constructor, and health check method. Corresponding changes have also been made to the `test/health.e2e-spec.ts` file to reflect the removal of the 'bskyClient' from the health check.

Here are the key changes:

Removal of `BSkyService` from `HealthController`:

* [`src/health/health.controller.ts`](diffhunk://#diff-5bac5a23ca6c01f37770182b8da3c50c5cf41608903a0726236cdee87f38fcdbL8): Removed `BSkyService` from the import statements.
* [`src/health/health.controller.ts`](diffhunk://#diff-5bac5a23ca6c01f37770182b8da3c50c5cf41608903a0726236cdee87f38fcdbL18): Removed `bskyService` from the `HealthController` constructor.
* [`src/health/health.controller.ts`](diffhunk://#diff-5bac5a23ca6c01f37770182b8da3c50c5cf41608903a0726236cdee87f38fcdbL29): Removed the health check for 'bskyClient' in the `health` method of `HealthController`.

Changes in test file:

* [`test/health.e2e-spec.ts`](diffhunk://#diff-64a740c5353beec55521284fd3aa8d475205d665c9be1738fa435396fdd5fff0L83-L89): Removed 'bskyClient' from the expected health check results in the test cases.