### PR TITLE
Deal with all meta payloads

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       ".dto.ts",
       "./src/config/*",
       ".mock.ts"
-  ],
+    ],
     "coverageDirectory": "../coverage",
     "coverageThreshold": {
       "global": {

--- a/src/__mocks__/meta-message.mock.ts
+++ b/src/__mocks__/meta-message.mock.ts
@@ -1,3 +1,5 @@
+import { MetaPayload } from '../message/models/meta-message.model'
+
 export const mockEntry = [
     {
       id: '103969782746696',
@@ -21,7 +23,7 @@ export const mockEntry = [
               {
                 from: '5511999991234',
                 id: 'wamid.HBgNNTUxMTk5MDExNjU1NRUCABIYFsWEQjA2QzEzMzM4QzhEMTFFRDgyNjkA',
-                timestamp: '1714873932',
+                timestamp: 1714873932,
                 text: {
                   body: 'Some post',
                 },
@@ -39,3 +41,71 @@ export const mockMetaMessage = {
     object: 'whatsapp_business_account',
     entry: mockEntry
 }
+
+const messageTypes = {
+  message: () => ({
+    contacts: [
+      {
+        profile: {
+          name: 'Ada Lovelace',
+        },
+        wa_id: '5511999991234',
+      },
+    ],
+    messages: [
+      {
+        from: '5511999991234',
+        id: 'wamid.HBgNNTUxMTk5MDExNjU1NRUCABIYFsWEQjA2QzEzMzM4QzhEMTFFRDgyNjkA',
+        timestamp: 1714873932,
+        text: {
+          body: 'New post',
+        },
+        type: 'text',
+      },
+    ],
+  }),
+  status: () => ({
+    statuses: [
+      {
+        id: 'wamid.HBgNNTUxMTk5MDExNjU1NRUCABEYEjU1MzE4NTYxRjk5NzI1MkEyRgA=',
+        status: 'sent',
+        timestamp: Date.now(),
+        recipient_id: '5511999991234',
+        conversation: {
+          id: 'cae087203c7ac27b847335769856f491',
+          expiration_timestamp: 1714873932,
+          origin: {
+            type: 'user_initiated',
+          },
+        },
+        pricing: {
+          billable: true,
+          pricing_model: 'CBP',
+          category: 'user_initiated',
+        },
+      },
+    ],
+  }),
+}
+
+export const mockMetaPayload = (type: string): MetaPayload => ({
+  object: 'whatsapp_business_account',
+  entry: [
+    {
+      id: '103969782746696',
+      changes: [
+        {
+          value: {
+            messaging_product: 'whatsapp',
+            metadata: {
+              display_phone_number: '5511912344321',
+              phone_number_id: '123456789012345',
+            },
+            ...messageTypes[type](),
+          },
+          field: 'messages',
+        },
+      ],
+    },
+  ]
+})

--- a/src/message/message.controller.ts
+++ b/src/message/message.controller.ts
@@ -26,7 +26,7 @@ export class MessageController {
   async getHello(@Body() messageData: MetaMessageDTO) {
     const t0 = performance.now();
     
-    await this.messageService.handleMessage(messageData);
+    await this.messageService.handleMessage(messageData.entry);
 
     this.logger.log(JSON.stringify({
       body: messageData,

--- a/src/message/service/message.service.spec.ts
+++ b/src/message/service/message.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MessageService } from './message.service';
 import { SocialService } from '../../social/services/social.service';
-import { MetaPayload } from '../models/meta-message.model';
+import { mockMetaPayload } from '../../__mocks__/meta-message.mock';
 
 describe('MessageService', () => {
   let service: MessageService;
@@ -44,41 +44,28 @@ describe('MessageService', () => {
   });
 
   it('should reply message with valid true', async () => {
-    const mockData = {
-      entry: [
-        {
-          changes: [
-            {
-              value: {
-                messages: [
-                  {
-                    type: 'text',
-                    from: '5511444412345',
-                    text: {
-                      body: 'New tuite',
-                    },
-                  },
-                ],
-                metadata: {
-                  phone_number_id: '5511432112345',
-                },
-              },
-            },
-          ],
-        },
-      ],
-    };
+    const mockData = mockMetaPayload('message').entry
 
     jest
       .spyOn(mockSocialService, 'reply')
       .mockImplementation(() => Promise.resolve(void 0));
 
-    await service.handleMessage(mockData as MetaPayload);
+    await service.handleMessage(mockData);
     expect(mockSocialService.reply).toHaveBeenCalledWith({
-      from: '5511444412345',
-      message: 'New tuite',
-      phoneNumberId: '5511432112345',
-      valid: true,
+      from: '5511999991234',
+      message: 'New post',
+      phoneNumberId: '123456789012345'
     });
   });
+
+  it('should not reply message with type different from text', async () => {
+    const mockData = mockMetaPayload('status').entry
+
+    jest
+      .spyOn(mockSocialService, 'reply')
+      .mockImplementation(() => Promise.resolve(void 0));
+
+    await service.handleMessage(mockData);
+    expect(mockSocialService.reply).not.toHaveBeenCalled();
+  })
 });

--- a/src/message/service/message.service.ts
+++ b/src/message/service/message.service.ts
@@ -18,7 +18,7 @@ export class MessageService {
     if(Object.keys(data[0].changes[0].value).includes('messages')) {
       const message = data[0].changes[0]?.value?.['messages'][0];
     
-      if(message?.type === 'text' && message?.text?.body !== 'teste') {
+      if(message?.type === 'text') {
         await this.reply({
           from: message.from,
           message: message.text.body,

--- a/src/message/service/message.service.ts
+++ b/src/message/service/message.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { SocialService } from '../../social/services/social.service';
-import { MetaPayload } from '../models/meta-message.model';
+import { WBPayloadEntry } from '../models/meta-message.model';
 
 @Injectable()
 export class MessageService {
@@ -12,22 +12,19 @@ export class MessageService {
     from: string;
     message: string;
     phoneNumberId: string;
-    valid: boolean;
   }) => this.socialService.reply(data);
 
-  handleMessage = async(data: MetaPayload) => {
-    const message = data.entry?.[0]?.changes[0]?.value?.['messages'][0];
+  handleMessage = async(data: WBPayloadEntry[]) => {
+    if(Object.keys(data[0].changes[0].value).includes('messages')) {
+      const message = data[0].changes[0]?.value?.['messages'][0];
     
-    if(message?.type === 'text' && message?.text?.body !== 'teste') {
-      const business_phone_number_id =
-        data.entry?.[0].changes?.[0].value?.metadata?.phone_number_id;
-
-      await this.reply({
-        from: message.from,
-        message: message.text.body,
-        phoneNumberId: business_phone_number_id,
-        valid: message?.type === 'text',
-      });
+      if(message?.type === 'text' && message?.text?.body !== 'teste') {
+        await this.reply({
+          from: message.from,
+          message: message.text.body,
+          phoneNumberId: data[0].changes[0].value.metadata.phone_number_id
+        });
+      }
     }
   }
 }

--- a/src/social/services/social.service.spec.ts
+++ b/src/social/services/social.service.spec.ts
@@ -106,8 +106,7 @@ describe('SocialService', () => {
     const mockData = {
       message: mockMessage,
       from: mockFrom,
-      phoneNumberId: mockPhoneNumberId,
-      valid: true
+      phoneNumberId: mockPhoneNumberId
     };
     await service.reply(mockData);
     expect(mockMetaService.sendMessage).toHaveBeenCalledWith({
@@ -118,7 +117,7 @@ describe('SocialService', () => {
     expect(service.whatsPost).toHaveBeenCalledWith(mockData);
   });
 
-  it('should reply to a message via whatsapp with invalid type', async () => {
+  it('should not post a message with test', async () => {
     jest.spyOn(mockMetaService, 'sendMessage').mockImplementation(() =>
       Promise.resolve({
         id: 'amid.HBgNNTUxMTk5MDExNjU1NRUCABEYEjdFRkNERTk5NjQ5OUJCMDk0MAA=',
@@ -126,18 +125,17 @@ describe('SocialService', () => {
     );
     jest.spyOn(service, 'whatsPost')
 
-    const mockMessage = 'New tuite';
+    const mockMessage = 'Test';
     const mockFrom = '5511444412345';
     const mockPhoneNumberId = '5511432112345';
     const mockData = {
       message: mockMessage,
       from: mockFrom,
-      phoneNumberId: mockPhoneNumberId,
-      valid: false
+      phoneNumberId: mockPhoneNumberId
     };
     await service.reply(mockData);
     expect(mockMetaService.sendMessage).toHaveBeenCalledWith({
-      message: 'Type not supported',
+      message: 'Reply your test. Not posted on social!',
       from: mockFrom,
       phoneNumberId: mockPhoneNumberId,
     });

--- a/src/social/services/social.service.ts
+++ b/src/social/services/social.service.ts
@@ -11,6 +11,12 @@ export class SocialService {
     private readonly metaService: MetaService,
   ) {}
 
+  private sendMessageToUser = async (data: {
+    from: string;
+    message: string;
+    phoneNumberId: string;
+  }) => this.metaService.sendMessage(data);
+
   webPost = async (
     message: string,
   ): Promise<{
@@ -51,7 +57,7 @@ export class SocialService {
     const { twitter, bsky } = await this.webPost(data.message);
 
     if (twitter.data.id) {
-      this.metaService.sendMessage({
+      this.sendMessageToUser({
         from: data.from,
         message: 'Twet posted successfully',
         phoneNumberId: data.phoneNumberId,
@@ -59,7 +65,7 @@ export class SocialService {
     }
 
     if (bsky.cid) {
-      this.metaService.sendMessage({
+      this.sendMessageToUser({
         from: data.from,
         message: 'BSky posted successfully',
         phoneNumberId: data.phoneNumberId,
@@ -80,14 +86,13 @@ export class SocialService {
     message: string;
     from: string;
     phoneNumberId: string;
-    valid: boolean;
   }): Promise<void> => {
     await this.metaService.sendMessage({
       from: data.from,
-      message: data.valid ? 'Processing your posts' : 'Type not supported',
+      message: data.message.toLowerCase() === 'test' ? 'Reply your test. Not posted on social!' : 'Processing your posts',
       phoneNumberId: data.phoneNumberId,
     });
 
-    if(data.valid) this.whatsPost(data);
+    if(data.message.toLowerCase() != 'test') this.whatsPost(data)
   };
 }


### PR DESCRIPTION
This pull request primarily focuses on improving the handling and testing of messages in the `src/message` and `src/social` directories. The changes include importing and using mock data, modifying function parameters, and refining the conditions for message processing.

Changes to the `src/__mocks__/meta-message.mock.ts` file:

* Imported `MetaPayload` from the `meta-message.model` file.
* Changed the `timestamp` type from `string` to `number` in `mockEntry`.
* Added `messageTypes` and `mockMetaPayload` to generate different types of messages for testing.

Changes to the `src/message` directory:

* In `message.controller.ts`, changed the parameter of `this.messageService.handleMessage()` from `messageData` to `messageData.entry`.
* In `message.service.spec.ts`, replaced the hardcoded `mockData` with `mockMetaPayload` from `meta-message.mock`. 

Changes to the `src/social` directory:

* In `social.service.spec.ts`, removed `phoneNumberId` and `valid` from `mockData` and updated the test cases accordingly.
* In `social.service.ts`, added `sendMessageToUser` method, replaced `this.metaService.sendMessage()` with `this.sendMessageToUser()`, and updated the conditions in `reply` method. 