### PR TITLE
[refactor]use Promise.allSettled

### DIFF
--- a/src/social/client/bsky.service.spec.ts
+++ b/src/social/client/bsky.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BSkyService } from './bsky.service';
 import { ConfigService } from '@nestjs/config';
+import { InternalServerErrorException } from '@nestjs/common';
 
 const mockLogin = jest.fn();
 const mockPost = jest.fn();
@@ -55,15 +56,14 @@ describe('BSkyService', () => {
 
   it('should throw an error when post creation fails', async () => {
     mockPost.mockImplementation(() => Promise.reject(new Error('Failed to create post')));
-    const response = await service.post('New post')
+    
+    await expect(service.post('New post')).rejects.toThrow(
+      new InternalServerErrorException('Failed to post'),
+    );
     expect(mockLogin).toHaveBeenCalled();
     expect(mockPost).toHaveBeenCalledWith({
       text: 'New post',
       createdAt: expect.any(String),
-    });
-    expect(response).toMatchObject({
-      message: 'Failed to post!',
-      error: 'Failed to create post',
     });
   });
 

--- a/src/social/client/bsky.service.ts
+++ b/src/social/client/bsky.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { BskyAgent, ComAtprotoServerCreateSession } from '@atproto/api';
 import { BskyResponse } from '../model/bsky-response.model';
@@ -35,10 +35,7 @@ export class BSkyService {
       return response
     } catch (error) {
       this.logger.error(error.message);
-      return {
-        message: 'Failed to post!',
-        error: error.message,
-      }
+      throw new InternalServerErrorException('Failed to post');
     }
   };
 

--- a/src/social/client/twitter.service.spec.ts
+++ b/src/social/client/twitter.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TwitterService } from './twitter.service';
 import { ConfigService } from '@nestjs/config';
+import { InternalServerErrorException } from '@nestjs/common';
 
 const mockCreateTweet = jest.fn();
 const mockAccountSettings = jest.fn();
@@ -60,11 +61,12 @@ describe('TwitterService', () => {
       Promise.reject(new Error('Error creating a new post')),
     );
 
-    const response = await service.post('New tuite')
-    expect(response).toMatchObject({
-        message: 'Failed to post!',
-        error: 'Error creating a new post',
-      });
+    await expect(service.post('New tuite')).rejects.toThrow(
+      new InternalServerErrorException('Failed to post!'),
+    );
+    expect(mockCreateTweet).toHaveBeenCalledWith({
+      text: 'New tuite',
+    })
   });
 
   it('should return account settings', async () => {

--- a/src/social/client/twitter.service.ts
+++ b/src/social/client/twitter.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   TwitterClient,
@@ -33,10 +33,7 @@ export class TwitterService {
       return response
     } catch (error) {
       this.logger.error(error.message);
-      return {
-        message: 'Failed to post!',
-        error: error.message,
-      }
+      throw new InternalServerErrorException('Failed to post!');
     }
   }
 

--- a/src/social/services/social.service.spec.ts
+++ b/src/social/services/social.service.spec.ts
@@ -283,4 +283,60 @@ describe('SocialService', () => {
       },
     });
   });
+
+  it('should create a twitter post, if bsky faild', async () => {
+    jest.spyOn(mockTwitterService, 'post').mockImplementation(() =>
+      Promise.resolve({
+        data: {
+          id: '1786581556854714590',
+          text: 'New tuite',
+        },
+      }),
+    );
+    jest.spyOn(mockBSkyService, 'post').mockImplementation(() =>
+      Promise.reject(new Error('Failed to create post'))
+    );
+
+    const response = await service.webPost('New tuite');
+    expect(mockTwitterService.post).toBeCalledWith('New tuite');
+    expect(mockBSkyService.post).toBeCalledWith('New tuite');
+    expect(response).toMatchObject({
+      twitter: {
+        data: {
+          id: '1786581556854714590',
+          text: 'New tuite',
+        },
+      },
+      bsky: {
+        message: 'Failed to post!',
+        error: 'Error creating a new post',
+      },
+    });
+  })
+
+  it('should create a bsky post, if twitter faild', async () => {
+    jest.spyOn(mockTwitterService, 'post').mockImplementation(() =>
+      Promise.reject(new Error('Failed to create post'))
+    );
+    jest.spyOn(mockBSkyService, 'post').mockImplementation(() =>
+      Promise.resolve({
+        uri: 'at://did:plc:fpnfkdvsz3pcjkfeyltowzuk/app.bsky.feed.post/3krmxwxnkzo27',
+        cid: 'bafyreiebo6vnunvzir2tgf3rr732j34ecmnrsz75fssjkugqu6yeoprfoq',
+      }),
+    );
+
+    const response = await service.webPost('New tuite');
+    expect(mockTwitterService.post).toBeCalledWith('New tuite');
+    expect(mockBSkyService.post).toBeCalledWith('New tuite');
+    expect(response).toMatchObject({
+      twitter: {
+        message: 'Failed to post!',
+        error: 'Error creating a new post',
+      },
+      bsky: {
+        uri: 'at://did:plc:fpnfkdvsz3pcjkfeyltowzuk/app.bsky.feed.post/3krmxwxnkzo27',
+        cid: 'bafyreiebo6vnunvzir2tgf3rr732j34ecmnrsz75fssjkugqu6yeoprfoq',
+      },
+    });
+  })
 });

--- a/src/social/services/social.service.ts
+++ b/src/social/services/social.service.ts
@@ -28,14 +28,20 @@ export class SocialService {
     twitter: CreateTweet | SocialError;
     bsky: BskyResponse | SocialError;
   }> => {
-    const [twitter, bsky] = await Promise.all([
+    const [ twitter, bsky ] = await Promise.allSettled([
       this.twitterService.post(message),
       this.bskyService.post(message),
     ]);
 
     return {
-      twitter,
-      bsky,
+      twitter: twitter.status === 'fulfilled' ? twitter.value : {
+        message: 'Failed to post!',
+        error: 'Error creating a new post',
+      },
+      bsky: bsky.status === 'fulfilled' ? bsky.value : {
+        message: 'Failed to post!',
+        error: 'Error creating a new post',
+      },
     };
   };
 


### PR DESCRIPTION
This pull request mainly focuses on improving error handling in the social client services (`BSkyService` and `TwitterService`) and the `SocialService`. It includes changes to throw `InternalServerErrorException` instead of returning an error object when a post creation fails in `BSkyService` and `TwitterService`. It also includes changes to handle rejected promises in `SocialService` using `Promise.allSettled` instead of `Promise.all`.

Error handling improvements:

* `src/social/client/bsky.service.spec.ts` and `src/social/client/bsky.service.ts`: Imported `InternalServerErrorException` and modified tests and service methods to throw an `InternalServerErrorException` when post creation fails instead of returning an error object.
* `src/social/client/twitter.service.spec.ts` and `src/social/client/twitter.service.ts`: Similar changes as above for the `TwitterService`.

Changes in `SocialService`:

* `src/social/services/social.service.spec.ts` and `src/social/services/social.service.ts`: Modified the `webPost` method to use `Promise.allSettled` instead of `Promise.all` to handle rejected promises and added tests for scenarios where one of the services fails to create a post. 