### PR TITLE
[feat]add bsky health

### DIFF
--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -14,6 +14,7 @@ export class HealthController {
 
   constructor(
     private readonly twitterService: TwitterService,
+    private readonly bskyService: MetaService,
     private readonly metaService: MetaService,
     private readonly healtCheckService: HealthCheckService,
   ) {}
@@ -24,6 +25,7 @@ export class HealthController {
   async health() {
     return this.healtCheckService.check([
       () => this.checkStatus('twitterClient', this.twitterService.health()),
+      () => this.checkStatus('bSkyClient', this.bskyService.health()),
       () => this.checkStatus('metaClient', this.metaService.health()),
     ]);
   }

--- a/src/health/health.controller.ts
+++ b/src/health/health.controller.ts
@@ -7,6 +7,7 @@ import {
 import { TwitterService } from '../social/client/twitter.service';
 import { ApiOkResponse } from '@nestjs/swagger';
 import { MetaService } from '../social/client/meta.service';
+import { BSkyService } from '../social/client/bsky.service';
 
 @Controller()
 export class HealthController {
@@ -14,7 +15,7 @@ export class HealthController {
 
   constructor(
     private readonly twitterService: TwitterService,
-    private readonly bskyService: MetaService,
+    private readonly bskyService: BSkyService,
     private readonly metaService: MetaService,
     private readonly healtCheckService: HealthCheckService,
   ) {}

--- a/test/health.e2e-spec.ts
+++ b/test/health.e2e-spec.ts
@@ -80,11 +80,13 @@ describe('HealthController (e2e)', () => {
           status: 'ok',
           info: {
             twitterClient: { status: 'up' },
+            bSkyClient: { status: 'up' },
             metaClient: { status: 'up' },
           },
           error: {},
           details: {
             twitterClient: { status: 'up' },
+            bSkyClient: { status: 'up' },
             metaClient: { status: 'up' },
           },
         });


### PR DESCRIPTION
This pull request primarily introduces the `BSkyService` into the `HealthController` and its corresponding tests. The most significant changes include the addition of `BSkyService` in the import statements and constructor of `HealthController`, as well as the inclusion of `bSkyClient` in the health check and test assertions.

Here's a breakdown of the changes:

Addition of `BSkyService`:

* [`src/health/health.controller.ts`](diffhunk://#diff-5bac5a23ca6c01f37770182b8da3c50c5cf41608903a0726236cdee87f38fcdbR10-R18): Imported `BSkyService` from `../social/client/bsky.service` and added it as a constructor parameter in the `HealthController`. This allows the `HealthController` to use the services provided by `BSkyService`.

Inclusion of `bSkyClient` in health check:

* [`src/health/health.controller.ts`](diffhunk://#diff-5bac5a23ca6c01f37770182b8da3c50c5cf41608903a0726236cdee87f38fcdbR29): Included `bSkyClient` in the health check by calling `this.bskyService.health()` in the `health()` method. This ensures that the health of `bSkyClient` is checked during each health check.

Addition of `bSkyClient` in test assertions:

* [`test/health.e2e-spec.ts`](diffhunk://#diff-64a740c5353beec55521284fd3aa8d475205d665c9be1738fa435396fdd5fff0R83-R89): Added `bSkyClient` in the expected results of the test assertions. This verifies that `bSkyClient` is included in the health check results.