### PR TITLE
[feat]add recipient_type

### DIFF
--- a/src/bank/bank.service.spec.ts
+++ b/src/bank/bank.service.spec.ts
@@ -42,6 +42,7 @@ describe('BankService', () => {
       service: 'bank',
       content: {
         type: 'interactive',
+        recipient_type: 'individual',
         interactive: {
           type: 'button',
           body: {

--- a/src/bank/bank.service.ts
+++ b/src/bank/bank.service.ts
@@ -13,6 +13,7 @@ export class BankService {
       service: 'bank',
       content: {
         type: 'interactive',
+        recipient_type: 'individual',
         interactive: {
           type: 'button',
           body: {

--- a/src/message/models/meta-message.model.ts
+++ b/src/message/models/meta-message.model.ts
@@ -68,7 +68,7 @@ export interface QuickReplyReceived extends MetaMessage {
 export interface WBPayloadEntry {
   id: string;
   changes: Array<{
-    value: MessageReceived | UpdateStatus;
+    value: MessageReceived | UpdateStatus | QuickReplyReceived;
     field: 'messages';
   }>;
 }

--- a/src/social/model/whats-message.model.ts
+++ b/src/social/model/whats-message.model.ts
@@ -19,6 +19,7 @@ interface ButtonData {
 
 export interface ButtonContent {
   type: string; // 'interactive'
+  recipient_type: string; // 'individual'
   interactive: {
     type: string; // 'button'
     body: {

--- a/src/social/services/social.service.spec.ts
+++ b/src/social/services/social.service.spec.ts
@@ -3,7 +3,6 @@ import { SocialService } from './social.service';
 import { TwitterService } from '../client/twitter.service';
 import { BSkyService } from '../client/bsky.service';
 import { MetaService } from '../client/meta.service';
-import { mock } from 'node:test';
 
 describe('SocialService', () => {
   let service: SocialService;
@@ -267,6 +266,7 @@ describe('SocialService', () => {
     const mockPhoneNumberId = '5511432112345';
     const mockContent = {
       type: 'interactive',
+      recipient_type: 'individual',
       interactive: {
         type: 'button',
         body: {

--- a/test/__mocks__/meta-received-data.mock.ts
+++ b/test/__mocks__/meta-received-data.mock.ts
@@ -4,7 +4,7 @@ interface MockMetaMessage {
   sender: string;
   receiver: string;
   message: string;
-  type: 'message' | 'status';
+  type: 'message' | 'status' | 'button';
   phoneNumberId?: string;
 }
 
@@ -52,6 +52,32 @@ const messageTypes = {
       },
     ],
   }),
+  button: (data: MockMetaMessage) => ({
+    contacts: [
+      {
+        profile: {
+          name: 'NAME',
+        },
+        wa_id: data.receiver,
+      },
+    ],
+    messages: [
+      {
+        context: {
+          from: data.receiver,
+          id: 'wamid.HBgNNTUxMTk5MDExNjU1NRUCABEYEjU1MzE4NTYxRjk5NzI1MkEyRgA=',
+        },
+        from: data.sender,
+        id: 'wamid.HBgNNTUxMTk5MDExNjU1NRUCABEYEjU1MzE4NTYxRjk5NzI1MkEyRgA=',
+        timestamp: Date.now(),
+        type: 'button',
+        button: {
+          text: 'Action',
+          payload: 'button-payload',
+        },
+      },
+    ],
+  }),
 };
 
 export const mockMetaMessage = (data: MockMetaMessage): MetaMessageDTO => ({
@@ -63,15 +89,10 @@ export const mockMetaMessage = (data: MockMetaMessage): MetaMessageDTO => ({
         {
           value: {
             messaging_product: 'whatsapp',
-            metadata: Object.keys(data).includes('phoneNumberId')
-              ? {
-                  display_phone_number: data.receiver,
-                  phone_number_id: data.phoneNumberId,
-                }
-              : {
-                  display_phone_number: data.receiver,
-                  phone_number_id: '123456378901234',
-                },
+            metadata: {
+              display_phone_number: data.receiver,
+              phone_number_id: data.phoneNumberId ?? '123456378901234',
+            },
             ...messageTypes[data.type](data),
           },
           field: 'messages',

--- a/test/message.e2e-spec.ts
+++ b/test/message.e2e-spec.ts
@@ -45,7 +45,7 @@ describe('MessageController (e2e)', () => {
 
   describe('receive message from meta', () => {
     describe('answer message to user', () => {
-      it('return 200 when receive a message', async() => {
+      it('return 200 when receive a message', async () => {
         const mockCompanyPhone = '551199991234';
         const mockCustomerPhone = '5511999991111';
         nock(`${mockUrl}/${mockPhoneNumberId}/messages`)
@@ -71,6 +71,41 @@ describe('MessageController (e2e)', () => {
           .send(
             mockMetaMessage({
               message: 'Some message',
+              receiver: mockCompanyPhone,
+              sender: mockCustomerPhone,
+              phoneNumberId: mockPhoneNumberId,
+              type: 'message',
+            }),
+          )
+          .expect(200);
+      });
+
+      it('return 200 when receive a reply message /bank', async () => {
+        const mockCompanyPhone = '551199991234';
+        const mockCustomerPhone = '5511999991111';
+        nock(`${mockUrl}/${mockPhoneNumberId}/messages`)
+          .post('')
+          .times(3)
+          .reply(200, {
+            messaging_product: 'whatsapp',
+            contacts: [
+              {
+                input: mockCustomerPhone,
+                wa_id: mockCustomerPhone,
+              },
+            ],
+            messages: [
+              {
+                id: 'amid.HBgNNTUxMTk5MDExNjU1NRUCABEYEjdFRkNERTk5NjQ5OUJCMDk0MAA=',
+              },
+            ],
+          });
+
+        return request(app.getHttpServer())
+          .post('/message')
+          .send(
+            mockMetaMessage({
+              message: '/bank',
               receiver: mockCompanyPhone,
               sender: mockCustomerPhone,
               phoneNumberId: mockPhoneNumberId,


### PR DESCRIPTION
This pull request primarily focuses on the enhancement of the messaging functionality in the application. The changes include the addition of a `recipient_type` field in the message content, expanding the `value` field in `WBPayloadEntry` interface, and updating the test cases to accommodate these changes. 

Addition of `recipient_type` field:

* [`src/bank/bank.service.spec.ts`](diffhunk://#diff-8cf28ad93a2673e82ad0910b1238524df3dc64dac5b6356b1d0d1dc5a5b37826R45): Added `recipient_type` field in the message content in `BankService` test.
* [`src/bank/bank.service.ts`](diffhunk://#diff-07e41f6107135acb17384cb0f8021daabf66a5b80405a16c0e50c830635aa5c9R16): Added `recipient_type` field in the message content in `BankService` class.
* [`src/social/model/whats-message.model.ts`](diffhunk://#diff-644999f65800f87ca5a7feb25fdb0f364afe30fef77e06315d908c168eedddf0R22): Added `recipient_type` field in the `ButtonContent` interface.
* [`src/social/services/social.service.spec.ts`](diffhunk://#diff-b8bd6083f508dd88eda5282530c8eebff9775a1754d5327908dd48036f2e2212R269): Added `recipient_type` field in the message content in `SocialService` test.

Expansion of `value` field:

* [`src/message/models/meta-message.model.ts`](diffhunk://#diff-c393835ef9dcf76d991db170e9b02b7689fe3ad281dd789e9229a427148ee4b3L71-R71): Expanded the `value` field in `WBPayloadEntry` interface to include `QuickReplyReceived`.

Test case updates:

* [`test/__mocks__/meta-received-data.mock.ts`](diffhunk://#diff-855d01e28da3e81c473062225c3d2fdfdde35f406a4cfdfa73db9cc529a83d8cL7-R7): Updated the `MockMetaMessage` interface and `messageTypes` constant to include 'button' type, and modified `mockMetaMessage` function to handle the case when `phoneNumberId` is not provided in the data.\
* [`src/social/services/social.service.spec.ts`](diffhunk://#diff-b8bd6083f508dd88eda5282530c8eebff9775a1754d5327908dd48036f2e2212L6): Removed unnecessary import of `mock` from 'node:test'.
* [`test/message.e2e-spec.ts`](diffhunk://#diff-efce309ebda3cec166a73434d902948384936229b5278fb6b98c68c283c97561R82-R116): Added a new test case to check the response when a reply message is received.